### PR TITLE
Update hostif.c

### DIFF
--- a/vmmon-only/linux/hostif.c
+++ b/vmmon-only/linux/hostif.c
@@ -1681,7 +1681,7 @@ HostIF_EstimateLockedPageLimit(const VMDriver* vm,                // IN
     */
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 0, 0)
-   extern unsigned long totalram_pages;
+   extern unsigned long totalram_pages(void);
    PageCnt totalPhysicalPages = totalram_pages;
 #else
    PageCnt totalPhysicalPages = totalram_pages();
@@ -1712,9 +1712,9 @@ HostIF_EstimateLockedPageLimit(const VMDriver* vm,                // IN
    lockedPages += global_node_page_state_pages(NR_SLAB_UNRECLAIMABLE_B);
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 13, 0)
    /* NR_SLAB_* moved from zone to node in 4.13. */
-   lockedPages += global_node_page_state(NR_SLAB_UNRECLAIMABLE);
+   lockedPages += global_node_page_state(NR_SLAB_UNRECLAIMABLE_B);
 #else
-   lockedPages += global_page_state(NR_SLAB_UNRECLAIMABLE);
+   lockedPages += global_page_state(NR_SLAB_UNRECLAIMABLE_B);
 #endif
    /* NR_UNEVICTABLE moved from global to node in 4.8. */
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)


### PR DESCRIPTION
Two Compilation errors with kernel 4.18.0-305.19.1.el8_4.x86_64 CentOS8 :

1) /root/vmware-host-modules-tmp-workstation-16/vmmon-only/linux/hostif.c:1684:25: error: 'totalram_pages' redeclared as different kind of symbol
    extern unsigned long totalram_pages;
                         ^~~~~~~~~~~~~~
In file included from /root/vmware-host-modules-tmp-workstation-16/vmmon-only/linux/hostif.c:42:
./include/linux/mm.h:56:29: note: previous definition of 'totalram_pages' was here
 static inline unsigned long totalram_pages(void)
                             ^~~~~~~~~~~~~~
2) /root/vmware-host-modules-tmp-workstation-16/vmmon-only/linux/hostif.c:1715:42: error: 'NR_SLAB_UNRECLAIMABLE' undeclared (first use in this function); did you mean 'NR_SLAB_UNRECLAIMABLE_B'?
    lockedPages += global_node_page_state(NR_SLAB_UNRECLAIMABLE);